### PR TITLE
Fix linux SAC w/ setArguments; Doc in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,22 @@
+# Building
+## Debian-based Linux
+
+Get QT5 development files
+```
+apt install qtbase5-dev-tools qtbase5-dev libqt5svg5-dev qt5-qmake
+```
+
+Use `qmake` and `make` to build
+
+```
+qmake -o SAC-build/Makefile StandaloneClient/SAC.pro 
+make -C SAC-build
+
+# run 
+SAC-build/SAC
+```
+
+
+> [!NOTE]
+> Tested 2025-06-15 on debian 12 "bookworm" with QMake version 3.1 Using Qt version 5.15.8
+

--- a/Client/rds_exechelper.cpp
+++ b/Client/rds_exechelper.cpp
@@ -52,7 +52,16 @@ bool rdsExecHelper::run(QString cmdLine, QString nativeArguments)
     ti.start();
     timeoutTimer.start();
     if (!nativeArguments.isEmpty()){
+        // https://www.qthub.com/static/doc/qt5/qtcore/qprocess.html#setNativeArguments
+        // > Note: This function is available only on the Windows platform.
+        // 2025-06-15 debian Qt 5.15.8
+        // error: ‘class QProcess’ has no member named ‘setNativeArguments’; did you mean ‘setArguments’?
+        #ifdef Q_OS_WIN
         myProcess->setNativeArguments(nativeArguments);
+        #else
+        // splitting on space is going to be a problem for e.g. "quoted arguments with space"!
+        myProcess->setArguments(nativeArguments.split(' '));
+        #endif
     }
 //    else {
 //        myProcess->start(cmdLine, arguments);

--- a/NetLogger/netlog_events.h
+++ b/NetLogger/netlog_events.h
@@ -9,7 +9,7 @@
 #define NETLOG_POST_TIMEOUT     30000
 #define NETLOG_EVENT_TIMEOUT    5000
 #define NETLOG_NSLOOKUP_TIMEOUT 10000
-
+#include <iostream>
 
 // Event definitions
 namespace EventInfo

--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ The source is released under the GNU General Public License, GPL (http://www.gnu
 
 ## More Information
 More information can be found on the project website https://yarra-framework.org.
+
+## Building
+See [BUILD.md](BUILD.md)

--- a/StandaloneClient/main.cpp
+++ b/StandaloneClient/main.cpp
@@ -1,6 +1,6 @@
 #include "sac_mainwindow.h"
 #include <QtCore>
-#include <QtGUI>
+#include <QtGui>
 #include <QApplication>
 #include <QStyleFactory>
 #include "sac_batchdialog.h"


### PR DESCRIPTION
nativeArguments.split(' ') is likely error proned quick fix. Splits arguments on space regardless of quote or escape

 * rds_exechelper.cpp used windows only setNativeArguments
   - preprocessor conditional to call setArguments if not Q_OS_WIN
 * QtGui case adjusted (was QtGUI)
 * iostream included to fixed error in NetLogger/netlog_events.h